### PR TITLE
fix: Assert Json file for importing package.json

### DIFF
--- a/index.js
+++ b/index.js
@@ -127,7 +127,7 @@ async function init() {
     write(file)
   }
 
-  const { default: pkg } = await import(path.join(templateDirectory, `package.json`))
+  const { default: pkg } = await import(path.join(templateDirectory, `package.json`), { assert: { type: "json", } })
 
   pkg.name = projectName || targetDirectory;
 

--- a/package.json
+++ b/package.json
@@ -17,5 +17,9 @@
   "devDependencies": {
     "@types/yargs": "^17.0.8"
   },
-  "repository": "git://github.com/jaredtbrown/create-dulo-app.git"
+  "repository": "git://github.com/jaredtbrown/create-dulo-app.git",
+  "engines": {
+    "npm": ">=8.3.0",
+    "node": ">=16.4.0"
+  }
 }


### PR DESCRIPTION
# Overview
This fixes a bug where users on node `16.4.0` and higher were getting an error trying to run the `create dulo-app` script.

This also adds an asserion that node `16.4.0` and higher is required for this package.